### PR TITLE
Ajout d'un exemple d'AJAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,32 @@ Cette fonction est exécutée à chaque clic du bouton et effectue plusieurs man
   ```
 
 La gestion de l'événement `click` du premier bouton de la page est faite directement dans le code HTML à travers `onclick="window.print()"`. Même si cette méthode est fonctionnelle, il est déconseillé de l'utiliser pour éviter d'alourdir le HTML et est donnée seulement à des fins de démonstration ici.
+
+## Requête HTTP avec JS
+
+Il est possible d'envoyer des requêtes `HTTP` à travers le code disponible dans la balise `<script>` du document `page2.html`. Cette page présente un exemple de la technique AJAX (_Asynchronous JavaScript and XML_) où une requête HTTP est envoyée par le code vers un serveur et la page est modifiée en fonction de la réponse reçue sans avoir à recharger la page. L'envoi de requête est _asynchrone_, c'est-à-dire que la page n'est bloquée en attendant la réponse du serveur.
+
+La page communique avec l'API (_Application Programming Interface_) [swapi](https://swapi.dev/) : un service qui donne accès à des informations de l'univers de _Star Wars_. 
+Dans cet exemple, l'interface permet de récupérer l'information de la population d'une planète en fonction de son identifiant et l'afficher à l'écran. _Note_ : certaines planètes n'ont pas cette information et la valeur `unkown` est alors affichée. La valeur maximale du champs de saisi, `61`, ne correspond à aucune planète.
+
+La valeur de l'identifiant est récupérée de la page et envoyée au serveur à travers la méthode `fetch` :
+
+```js
+const input = document.getElementById("planet-input");
+const serverResponse = await fetch(`https://swapi.dev/api/planets/${input.value}`);
+```
+Si le code de retour est `404` (Not Found), un message est affiché à l'écran. Sinon, le corps de la réponse est transformé en objet `JSON` (JavaScript Object Notation) et ses attributs `name` et `populations` sont affichés à l'écran :
+
+```js
+const messageField = document.getElementById("planet-result");
+if (serverResponse.status === 404) {
+  messageField.textContent = "Aucune planète trouvée";
+} else {
+  const jsonInfo = await serverResponse.json();
+  messageField.textContent = `La planette ${jsonInfo.name} a une population de ${jsonInfo.population}`;
+}
+```
+
+À titre d'exemple :
+- L'identifiant `1` retournera `La planette Tatooine a une population de 200000`.
+- L'identifiant `61` retournera `Aucune planète trouvée`.

--- a/page2.html
+++ b/page2.html
@@ -2,13 +2,32 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <title>Page HTML Minimale</title>
+    <title>Requêtes HTTP envoyés par le code JS (AJAX)</title>
+    <script>
+      async function getPlanetData() {
+        const input = document.getElementById("planet-input");
+        const serverResponse = await fetch(`https://swapi.dev/api/planets/${input.value}`);
+        const messageField = document.getElementById("planet-result");
+        if (serverResponse.status === 404) {
+          messageField.textContent = "Aucune planette trouvée";
+        } else {
+          const jsonInfo = await serverResponse.json();
+          messageField.textContent = `La planette ${jsonInfo.name} a une population de ${jsonInfo.population}`;
+        }
+      }
+    </script>
   </head>
   <body>
-    <header>Entête de la page</header>
+    <header>
+      <p>Trouver une planette dans l'univers de Star Wars</p>
+      <i>Information récupérée à l'aide de <a href="https://swapi.dev/">SWAPI</a> (Star Wars API)</i>
+    </header>
     <main>
-      <p>Hello World!</p>
+      <form id="planet-form" onsubmit="getPlanetData();return false">
+        <input type="number" min="1" max="61" id="planet-input" />
+        <button>Chercher</button>
+      </form>
+      <p id="planet-result"></p>
     </main>
-    <footer>Pied de page</footer>
   </body>
 </html>

--- a/page2.html
+++ b/page2.html
@@ -1,33 +1,47 @@
 <!DOCTYPE html>
 <html lang="fr">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Requêtes HTTP envoyés par le code JS (AJAX)</title>
-    <script>
-      async function getPlanetData() {
-        const input = document.getElementById("planet-input");
-        const serverResponse = await fetch(`https://swapi.dev/api/planets/${input.value}`);
-        const messageField = document.getElementById("planet-result");
-        if (serverResponse.status === 404) {
-          messageField.textContent = "Aucune planette trouvée";
-        } else {
-          const jsonInfo = await serverResponse.json();
-          messageField.textContent = `La planette ${jsonInfo.name} a une population de ${jsonInfo.population}`;
-        }
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Requêtes HTTP envoyés par le code JS (AJAX)</title>
+  <script>
+    async function getPlanetData() {
+      const input = document.getElementById("planet-input");
+      const serverResponse = await fetch(`https://swapi.dev/api/planets/${input.value}`);
+      const messageField = document.getElementById("planet-result");
+      if (serverResponse.status === 404) {
+        messageField.textContent = "Aucune planète trouvée";
+      } else {
+        const jsonInfo = await serverResponse.json();
+        messageField.textContent = `La planette ${jsonInfo.name} a une population de ${jsonInfo.population}`;
       }
-    </script>
-  </head>
-  <body>
-    <header>
-      <p>Trouver une planette dans l'univers de Star Wars</p>
+    }
+  </script>
+</head>
+
+<body>
+  <header>
+    <h2>Trouver une planette dans l'univers de Star Wars</h2>
+  </header>
+  <main>
+    <section id="info">
       <i>Information récupérée à l'aide de <a href="https://swapi.dev/">SWAPI</a> (Star Wars API)</i>
-    </header>
-    <main>
-      <form id="planet-form" onsubmit="getPlanetData();return false">
-        <input type="number" min="1" max="61" id="planet-input" />
+      <p>Les identifiants 1 à 60 retourneront la population d'une planète existante (certaines données auront la valeur
+        "unknown" pour leur population).
+      <p>
+      <p> L'id <em>61</em> obtiendra un code de retour <strong>404</strong> et affichera "Aucune planète trouvée" à la
+        place.</p>
+    </section>
+    <form id="planet-form" onsubmit="getPlanetData();return false">
+      <fieldset>
+        <legend>Population de planète</legend>
+        <label for="planet-input">Entrez un identifiant de planète :</label>
+        <input type="number" min="1" max="61" id="planet-input" value="1" />
         <button>Chercher</button>
-      </form>
-      <p id="planet-result"></p>
-    </main>
-  </body>
+      </fieldset>
+    </form>
+    <p id="planet-result"></p>
+  </main>
+</body>
+
 </html>


### PR DESCRIPTION
La page `page2` a été bonifié avec un exemple de requête HTTP envoyée par le code JS directement.
La page utilise [swapi](https://swapi.dev/) comme API externe.
Mise à jour du README pour expliquer le fonctionnement et la logique de la requête.